### PR TITLE
Fix G_TagGametype warning during intermissions

### DIFF
--- a/BattleMod/Lua/4-Hooks/Exec_Player.lua
+++ b/BattleMod/Lua/4-Hooks/Exec_Player.lua
@@ -383,6 +383,7 @@ end, MT_EXTRALARGEBUBBLE)
 --addHook("PlayerQuit", F.PlayerFlagBurst)
 
 addHook("ViewpointSwitch", function(...)
+    if gamestate ~= GS_LEVEL then return end
     if B.TagGametype() then
 		return B.TagViewpoints(...)
 	else


### PR DESCRIPTION
I don't know why a ViewpointSwitch hook can run during intermissions, but this adds a check so that it can't anymore.