### PR TITLE
Remove MT_DUSTDEVIL from a freeslot function

### DIFF
--- a/BattleMod/Lua/2-MobjStateInfo/2-Specials/Info_ActDustDevil.lua
+++ b/BattleMod/Lua/2-MobjStateInfo/2-Specials/Info_ActDustDevil.lua
@@ -1,6 +1,5 @@
 freeslot(
 	'mt_dustdevil_base',
-	'mt_dustdevil',
 	'mt_swirl'
 )
 


### PR DESCRIPTION
MT_DUSTDEVIL is already in SRB2, so freeslotting it again can cause issues.